### PR TITLE
remove unused classname when deploy liquid contract

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,12 @@ sourceSets {
             exclude '**/*.key'
             include 'bcos3_sol/WeCrossProxy.sol'
             include 'bcos3_sol/WeCrossHub.sol'
+            include 'bcos3_liquid/we_cross_proxy/we_cross_proxy.abi'
+            include 'bcos3_liquid/we_cross_proxy/we_cross_proxy.wasm'
+            include 'bcos3_liquid/we_cross_proxy/we_cross_proxy_gm.wasm'
+            include 'bcos3_liquid/we_cross_hub/we_cross_hub.abi'
+            include 'bcos3_liquid/we_cross_hub/we_cross_hub.wasm'
+            include 'bcos3_liquid/we_cross_hub/we_cross_hub_gm.wasm'
         }
     }
 

--- a/src/integTest/java/com/webank/wecross/stub/bcos3/integration/BCOSStubCallContractIntegTest.java
+++ b/src/integTest/java/com/webank/wecross/stub/bcos3/integration/BCOSStubCallContractIntegTest.java
@@ -443,7 +443,6 @@ public class BCOSStubCallContractIntegTest {
             args = new Object[]{
                     "HelloWorld",
                     abi,
-                    "HelloWorld",
                     wasm,
                     constructorParams
             };
@@ -502,7 +501,6 @@ public class BCOSStubCallContractIntegTest {
             args = new Object[] {
                     "TupleTest",
                     abi,
-                    "TupleTest",
                     wasm,
                     params1,
                     params2,
@@ -571,7 +569,6 @@ public class BCOSStubCallContractIntegTest {
             args = new Object[]{
                     baseName,
                     abi,
-                    baseName,
                     wasm,
                     constructorParams
             };

--- a/src/main/java/com/webank/wecross/stub/bcos3/BCOSBaseStubFactory.java
+++ b/src/main/java/com/webank/wecross/stub/bcos3/BCOSBaseStubFactory.java
@@ -3,6 +3,7 @@ package com.webank.wecross.stub.bcos3;
 import com.webank.wecross.stub.Account;
 import com.webank.wecross.stub.Connection;
 import com.webank.wecross.stub.Driver;
+import com.webank.wecross.stub.StubConstant;
 import com.webank.wecross.stub.StubFactory;
 import com.webank.wecross.stub.WeCrossContext;
 import com.webank.wecross.stub.bcos3.account.BCOSAccountFactory;
@@ -14,7 +15,6 @@ import com.webank.wecross.stub.bcos3.preparation.HubContractDeployment;
 import com.webank.wecross.stub.bcos3.preparation.ProxyContractDeployment;
 import java.io.File;
 import java.io.FileWriter;
-import java.net.URL;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.util.Map;
@@ -280,33 +280,144 @@ public class BCOSBaseStubFactory implements StubFactory {
 
     public void generateProxyContract(String path) {
         try {
-            String proxyPath = "WeCrossProxy.sol";
-            URL proxyDir =
+            // copy proxy sol file
+            FileUtils.copyURLToFile(
                     getClass()
                             .getResource(
                                     File.separator
-                                            + BCOSConstant.BCOS3
+                                            + BCOSConstant.BCOS3_SOL_DIR
                                             + File.separator
-                                            + proxyPath);
-            File dest =
-                    new File(path + File.separator + "WeCrossProxy" + File.separator + proxyPath);
-            FileUtils.copyURLToFile(proxyDir, dest);
+                                            + BCOSConstant.BCOS3_PROXY_SOL_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.PROXY_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_PROXY_SOL_FILE));
+
+            // copy proxy abi
+            FileUtils.copyURLToFile(
+                    getClass()
+                            .getResource(
+                                    File.separator
+                                            + BCOSConstant.BCOS3_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_PROXY_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_PROXY_LIQUID_ABI_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.PROXY_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_PROXY_LIQUID_ABI_FILE));
+
+            // copy proxy wasm
+            FileUtils.copyURLToFile(
+                    getClass()
+                            .getResource(
+                                    File.separator
+                                            + BCOSConstant.BCOS3_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_PROXY_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_PROXY_LIQUID_WASM_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.PROXY_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_PROXY_LIQUID_WASM_FILE));
+
+            // copy proxy gm wasm
+            FileUtils.copyURLToFile(
+                    getClass()
+                            .getResource(
+                                    File.separator
+                                            + BCOSConstant.BCOS3_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_PROXY_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_PROXY_LIQUID_GM_WASM_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.PROXY_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_PROXY_LIQUID_GM_WASM_FILE));
         } catch (Exception e) {
-            System.out.println(e);
+            logger.error("Copy proxy failed: ", e);
         }
     }
 
     public void generateHubContract(String path) {
         try {
-            String hubPath = "WeCrossHub.sol";
-            URL hubDir =
+            // copy hub sol
+            FileUtils.copyURLToFile(
                     getClass()
                             .getResource(
-                                    File.separator + BCOSConstant.BCOS3 + File.separator + hubPath);
-            File dest = new File(path + File.separator + "WeCrossHub" + File.separator + hubPath);
-            FileUtils.copyURLToFile(hubDir, dest);
+                                    File.separator
+                                            + BCOSConstant.BCOS3_SOL_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_SOL_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.HUB_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_HUB_SOL_FILE));
+            // copy hub abi
+            FileUtils.copyURLToFile(
+                    getClass()
+                            .getResource(
+                                    File.separator
+                                            + BCOSConstant.BCOS3_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_LIQUID_ABI_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.HUB_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_HUB_LIQUID_ABI_FILE));
+
+            // copy hub wasm
+            FileUtils.copyURLToFile(
+                    getClass()
+                            .getResource(
+                                    File.separator
+                                            + BCOSConstant.BCOS3_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_LIQUID_WASM_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.HUB_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_HUB_LIQUID_WASM_FILE));
+
+            // copy hub gm wasm
+            FileUtils.copyURLToFile(
+                    getClass()
+                            .getResource(
+                                    File.separator
+                                            + BCOSConstant.BCOS3_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_LIQUID_DIR
+                                            + File.separator
+                                            + BCOSConstant.BCOS3_HUB_LIQUID_GM_WASM_FILE),
+                    new File(
+                            path
+                                    + File.separator
+                                    + StubConstant.HUB_NAME
+                                    + File.separator
+                                    + BCOSConstant.BCOS3_HUB_LIQUID_GM_WASM_FILE));
         } catch (Exception e) {
-            System.out.println(e);
+            logger.error("Copy hub failed: ", e);
         }
     }
 }

--- a/src/main/java/com/webank/wecross/stub/bcos3/common/BCOSConstant.java
+++ b/src/main/java/com/webank/wecross/stub/bcos3/common/BCOSConstant.java
@@ -6,7 +6,18 @@ import com.webank.wecross.stub.StubConstant;
 public interface BCOSConstant {
     String ADMIN_ACCOUNT = "admin";
 
-    String BCOS3 = "bcos3_sol";
+    String BCOS3_SOL_DIR = "bcos3_sol";
+    String BCOS3_LIQUID_DIR = "bcos3_liquid";
+    String BCOS3_HUB_LIQUID_DIR = "we_cross_hub";
+    String BCOS3_PROXY_LIQUID_DIR = "we_cross_proxy";
+    String BCOS3_HUB_SOL_FILE = "WeCrossHub.sol";
+    String BCOS3_PROXY_SOL_FILE = "WeCrossProxy.sol";
+    String BCOS3_HUB_LIQUID_ABI_FILE = "we_cross_hub.abi";
+    String BCOS3_HUB_LIQUID_WASM_FILE = "we_cross_hub.wasm";
+    String BCOS3_HUB_LIQUID_GM_WASM_FILE = "we_cross_hub_gm.wasm";
+    String BCOS3_PROXY_LIQUID_ABI_FILE = "we_cross_proxy.abi";
+    String BCOS3_PROXY_LIQUID_WASM_FILE = "we_cross_proxy.wasm";
+    String BCOS3_PROXY_LIQUID_GM_WASM_FILE = "we_cross_proxy_gm.wasm";
 
     String SECP256K1 = "secp256k1";
     String SM2P256V1 = "sm2p256v1";

--- a/src/main/java/com/webank/wecross/stub/bcos3/custom/DeployContractHandler.java
+++ b/src/main/java/com/webank/wecross/stub/bcos3/custom/DeployContractHandler.java
@@ -82,37 +82,56 @@ public class DeployContractHandler implements CommandHandler {
 
         BCOSDriver driver = getAsyncBfsService().getBcosDriver();
         boolean isWasm = driver.isWasm();
-        List<String> params = null;
-        String abi;
-        String bin;
-        String className;
-        String bfsName;
 
         if (isWasm) {
-            if (Objects.isNull(args) || args.length < 4) {
+            if (Objects.isNull(args) || args.length < 3) {
                 callback.onResponse(new Exception("incomplete args"), null);
                 return;
             }
-            bfsName = (String) args[0];
-            abi = (String) args[1];
-            className = (String) args[2];
-            bin = (String) args[3];
+            String bfsName = (String) args[0];
+            String abi = (String) args[1];
+            String bin = (String) args[2];
+            List<String> params = null;
 
-            if (args.length > 4) {
+            if (args.length > 3) {
                 params = new ArrayList<>();
-                for (int i = 4; i < args.length; ++i) {
+                for (int i = 3; i < args.length; ++i) {
                     params.add((String) args[i]);
                 }
             }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("deploy contract, name: {}, bin: {}, abi:{}, params:{}", bfsName, bin, abi, params);
+            }
+
+            deployLiquidContractAndRegisterLink(
+                    path,
+                    bin,
+                    abi,
+                    params,
+                    account,
+                    connection,
+                    blockManager,
+                    (e, address) -> {
+                        if (Objects.nonNull(e)) {
+                            logger.error("deploy failed ", e);
+                            callback.onResponse(e, null);
+                            return;
+                        }
+
+                        logger.info(" address: {}", address);
+                        callback.onResponse(null, address);
+                    });
 
         } else {
             if (Objects.isNull(args) || args.length < 3) {
                 callback.onResponse(new Exception("incomplete args"), null);
                 return;
             }
-            bfsName = (String) args[0];
+            String bfsName = (String) args[0];
             String solidityContent = (String) args[1];
-            className = (String) args[2];
+            String className = (String) args[2];
+            List<String> params = null;
 
             if (args.length > 3) {
                 params = new ArrayList<>();
@@ -152,42 +171,19 @@ public class DeployContractHandler implements CommandHandler {
 
                 CompilationResult result = CompilationResult.parse(res.getOutput());
                 metadata = result.getContract(className);
-                abi = metadata.abi;
-                bin = metadata.bin;
             } catch (Exception e) {
                 logger.error("compiling contract failed, e: ", e);
                 callback.onResponse(new Exception("compiling contract failed"), null);
                 return;
             }
-        }
 
-        if (logger.isTraceEnabled()) {
-            logger.trace("deploy contract, name: {}, bin: {}, abi:{}", bfsName, bin, abi);
-        }
+            if (logger.isTraceEnabled()) {
+                logger.trace("deploy contract, name: {}, bin: {}, abi:{}", bfsName, metadata.bin, metadata.abi);
+            }
 
-        if (isWasm) {
-            deployLiquidContractAndRegisterLink(
-                    path,
-                    bin,
-                    abi,
-                    params,
-                    account,
-                    connection,
-                    blockManager,
-                    (e, address) -> {
-                        if (Objects.nonNull(e)) {
-                            logger.error("deploy failed ", e);
-                            callback.onResponse(e, null);
-                            return;
-                        }
-
-                        logger.info(" address: {}", address);
-                        callback.onResponse(null, address);
-                    });
-        } else {
             /* constructor params */
             ABIDefinitionFactory abiDefinitionFactory = new ABIDefinitionFactory(cryptoSuite);
-            ContractABIDefinition contractABIDefinition = abiDefinitionFactory.loadABI(abi);
+            ContractABIDefinition contractABIDefinition = abiDefinitionFactory.loadABI(metadata.abi);
             ABIDefinition constructor = contractABIDefinition.getConstructor();
             /* check if solidity constructor needs arguments */
             byte[] paramsABI = new byte[0];
@@ -232,8 +228,8 @@ public class DeployContractHandler implements CommandHandler {
 
             deploySolContractAndRegisterLink(
                     path,
-                    bin + Hex.toHexString(paramsABI),
-                    abi,
+                    metadata.bin + Hex.toHexString(paramsABI),
+                    metadata.abi,
                     account,
                     connection,
                     driver,


### PR DESCRIPTION
remove unused classname when deploy liquid contract。now deploy contract rule：
solidity param order：
* 0 => bfsName 
* 1 => solidityContent  
* 2 => className 
* 3.. => params 
wasm param order:
* 0 => bfsName 
* 1 => abi
* 2 => bin 
* 3.. => params
